### PR TITLE
fix: Load PlotlyJS library from CDN

### DIFF
--- a/src/pyright_analysis_action/action.py
+++ b/src/pyright_analysis_action/action.py
@@ -47,7 +47,9 @@ def action(
     results = schema.PyrightJsonResults.model_validate_json(data)
     figure = treemap.to_treemap(results.type_completeness)
 
-    html_page: str = figure.to_html(full_html=not embeddable, div_id=div_id)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    html_page: str = figure.to_html(  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+        full_html=not embeddable, div_id=div_id, include_plotlyjs="cdn"
+    )
     assert isinstance(html_page, str)
     preview = figure.to_image("svg", scale=0.5)  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
     assert isinstance(preview, bytes)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -45,7 +45,7 @@ class TestAction:
     def test_html_args_passthrough(self, embeddable: bool, div_id: str | None) -> None:
         action(self.report, embeddable=embeddable, div_id=div_id)
         self.mock_to_html.assert_called_once_with(
-            full_html=not embeddable, div_id=div_id
+            full_html=not embeddable, div_id=div_id, include_plotlyjs="cdn"
         )
 
     @pytest.mark.parametrize("smokeshow_auth_key", (None, "some-test-value"))


### PR DESCRIPTION
The generated HTML is shared online, so there is a network connection to load the Plotly JS library over CDN instead of embedding several MB in the HTML.

Fixes #18
